### PR TITLE
Fix - Back of Driving Licence scan issue

### DIFF
--- a/app/src/main/java/com/acuant/sampleapp/MainActivity.kt
+++ b/app/src/main/java/com/acuant/sampleapp/MainActivity.kt
@@ -1275,6 +1275,8 @@ class MainActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener {
                             }
                         })
                         backgroundTasks.add(task)
+                    } else {
+                        getData()                        
                     }
                 }
 


### PR DESCRIPTION
We were having the following issue with the sample app:

> When completing a submission on the latest Acuant sample app, the app gets stuck on "Getting Data" after scanning the back of a driving license.

Analyzing the network requests during a license driving capture shows the two sides uploaded and all network requests successful. When reaching the "Getting Data" alert, no further network request is observed.

Analyzing the code of the Sample App, the `imageUploaded` for the back of the driving license upload callback in MaintActivity.kt::1266 is called, but if no barcode scanning is expected, then no further action is performed by the SampleApp.

Forcing to perform the next action, an `else` statement, let the Sample App continue to the details screen with all info extracted correctly from the scanning.

Just posting here, maybe it can be helpful for others or could be fixed in the main repo.
